### PR TITLE
company-posframe-show: pass exact height and width (should improve performance)

### DIFF
--- a/company-posframe.el
+++ b/company-posframe.el
@@ -104,6 +104,7 @@ Using current frame's font if it it nil."
   "Show company-posframe candidate menu."
   (let* ((height (min company-tooltip-limit company-candidates-length))
          (lines (company--create-lines company-selection height))
+         (width (length (car lines)))
          (contents (mapconcat #'identity lines "\n"))
          (buffer (get-buffer-create company-posframe-buffer)))
     ;; FIXME: Do not support mouse at the moment, so remove mouse-face
@@ -114,6 +115,7 @@ Using current frame's font if it it nil."
     (posframe-show buffer
                    :string contents
                    :position (- (point) (length company-prefix))
+                   :height height :width width
                    :x-pixel-offset (* -1 company-tooltip-margin (default-font-width))
                    :font company-posframe-font
                    :min-width company-tooltip-minimum-width


### PR DESCRIPTION
Thanks for making this, company's bad interaction with variable font sizes is really annoying. Now I'm finally able to use variable-pitch-mode :smiley: 

Passing exact height and width to `posframe-show` seems to improve performance significantly when `company-posframe` changes size. Though I've only tested it in gnome shell where frame resize doesn't work correctly, https://github.com/tumashu/company-posframe/issues/2, so it could be a weird interaction there. On my setup it does make a big difference at least, the resize events got really laggy.
