### PR TITLE
Set width of marginal areas of the posframe buffer window to ZERO

### DIFF
--- a/company-posframe.el
+++ b/company-posframe.el
@@ -111,7 +111,9 @@ Using current frame's font if it it nil."
     (setq contents (copy-sequence contents))
     (remove-text-properties 0 (length contents) '(mouse-face nil) contents)
     (with-current-buffer buffer
-      (setq-local overriding-local-map company-posframe-active-map))
+      (setq-local overriding-local-map company-posframe-active-map)
+      ;; Set width of marginal areas of the buffer window to ZERO
+      (set-window-margins (get-buffer-window buffer) 0 0))
     (posframe-show buffer
                    :string contents
                    :position (- (point) (length company-prefix))


### PR DESCRIPTION
If the `left-margin-width` or `right-margin-width` of current display of a buffer is not `0`, the child frame created by company-posframe will have the same margin width. Like the screen shot below:

![screen shot 2019-03-02 at 10 37 35 pm](https://user-images.githubusercontent.com/1025559/53683463-ed976e80-3d3b-11e9-8016-e742332c4056.png)

This pull request is to fix the error.