### PR TITLE
Fix split-string nil error

### DIFF
--- a/company-posframe.el
+++ b/company-posframe.el
@@ -361,28 +361,28 @@ just grab the first candidate and press forward."
   (while-no-input
     (let* ((selected (nth company-selection company-candidates))
            (doc (let ((inhibit-message t))
-                  (company-posframe-quickhelp-doc selected)))
-           (width
-            (let ((n (apply #'max (mapcar #'string-width
-                                          (split-string doc "\n+")))))
-              (+ (min fill-column n) 1)))
-           (height
-            (max (+ company-tooltip-limit
-                    (if company-posframe-show-indicator 1 0)
-                    (if company-posframe-show-metadata 1 0))
-                 (with-current-buffer company-posframe-buffer
-                   (frame-height posframe--frame)))))
+                  (company-posframe-quickhelp-doc selected))))
       (when doc
-        (apply #'posframe-show
-               company-posframe-quickhelp-buffer
-               :string doc
-               :width width
-               :min-width width
-               :min-height height
-               :height height
-               :background-color (face-attribute 'company-posframe-quickhelp :background nil t)
-               :foreground-color (face-attribute 'company-posframe-quickhelp :foreground nil t)
-               company-posframe-quickhelp-show-params)))))
+        (let* ((width
+                (let ((n (apply #'max (mapcar #'string-width
+                                              (split-string doc "\n+")))))
+                  (+ (min fill-column n) 1)))
+               (height
+                (max (+ company-tooltip-limit
+                        (if company-posframe-show-indicator 1 0)
+                        (if company-posframe-show-metadata 1 0))
+                     (with-current-buffer company-posframe-buffer
+                       (frame-height posframe--frame)))))
+          (apply #'posframe-show
+                 company-posframe-quickhelp-buffer
+                 :string doc
+                 :width width
+                 :min-width width
+                 :min-height height
+                 :height height
+                 :background-color (face-attribute 'company-posframe-quickhelp :background nil t)
+                 :foreground-color (face-attribute 'company-posframe-quickhelp :foreground nil t)
+                 company-posframe-quickhelp-show-params))))))
 
 (defun company-posframe-quickhelp-right-poshandler (_info)
   (with-current-buffer company-posframe-buffer


### PR DESCRIPTION
In the event of a backend giving candidates without docs
we have to check if the doc exist before calling split-string

In ``company-posframe-quickhelp-show()``
the doc of current candidate is used in a `split-string call`. throwing an error in the case of `nil` doc:

![image](https://user-images.githubusercontent.com/15630634/73984042-06d77080-4938-11ea-959e-e67500def308.png)

proposed fix:
Move the existing check before the split-string call.
