### PR TITLE
Fix error in quickhelp on empty doc

### DIFF
--- a/company-posframe.el
+++ b/company-posframe.el
@@ -367,21 +367,24 @@ just grab the first candidate and press forward."
               (buffer-string))))))))
 
 (defun company-posframe-quickhelp-doc (selected)
-  (cl-letf (((symbol-function 'completing-read)
-             #'company-posframe-quickhelp-completing-read))
-    (let* ((header
-            (if company-posframe-quickhelp-show-header
-                (substitute-command-keys
-                 (concat
-                  "## "
-                  "\\<company-posframe-active-map>\\[company-posframe-quickhelp-toggle]:Show/Hide  "
-                  "\\<company-posframe-active-map>\\[company-posframe-quickhelp-scroll-up]:Scroll-Up  "
-                  "\\<company-posframe-active-map>\\[company-posframe-quickhelp-scroll-down]:Scroll-Down "
-                  "##\n")) ""))
-           (body (company-posframe-quickhelp-fetch-docstring selected))
-           (doc (concat (propertize header 'face 'company-posframe-quickhelp-header)
-                        (propertize body 'face 'company-posframe-quickhelp))))
-      doc)))
+  (let* ((body (company-posframe-quickhelp-fetch-docstring selected))
+         (doc
+          (if body
+              (cl-letf (((symbol-function 'completing-read)
+                         #'company-posframe-quickhelp-completing-read))
+                (let* ((header
+                        (if company-posframe-quickhelp-show-header
+                            (substitute-command-keys
+                             (concat
+                              "## "
+                              "\\<company-posframe-active-map>\\[company-posframe-quickhelp-toggle]:Show/Hide  "
+                              "\\<company-posframe-active-map>\\[company-posframe-quickhelp-scroll-up]:Scroll-Up  "
+                              "\\<company-posframe-active-map>\\[company-posframe-quickhelp-scroll-down]:Scroll-Down "
+                              "##\n")) ""))
+                       (doc (concat (propertize header 'face 'company-posframe-quickhelp-header)
+                                    (propertize body 'face 'company-posframe-quickhelp))))
+                  doc)))))
+    doc))
 
 (defun company-posframe-quickhelp-set-timer ()
   (when (null company-posframe-quickhelp-timer)


### PR DESCRIPTION
when the candidate has no docstring it causes an error in
`company-posframe-quickhelp-show`.
if `company-posframe-quikhelp-fetch-docstring` returns nil we can
skip the rest of the execution.

![image](https://user-images.githubusercontent.com/15630634/74861923-6fb4e480-534b-11ea-9162-9882d3f27bbf.png)

Could probably be written cleaner.