### PR TITLE
Make sure symbol-name is dealing with a symbol

### DIFF
--- a/company-posframe.el
+++ b/company-posframe.el
@@ -289,8 +289,9 @@ COMMAND: See `company-frontends'."
           (list (selected-window)
                 (current-buffer)))
     (let ((run-quickhelp-command-p
-           (string-match-p "^company-posframe-quickhelp-"
-                           (symbol-name this-command))))
+           (and (symbolp this-command)
+                (string-match-p "^company-posframe-quickhelp-"
+                                (symbol-name this-command)))))
       (cl-case command
         (pre-command
          (when (and company-posframe-quickhelp-delay


### PR DESCRIPTION
`this-command` can be a lambda, so it is not safe to pass it to `symbol-name`.

In my case, company-posframe died while using phi-search-mc.

```
Debugger entered--Lisp error: (wrong-type-argument symbolp (lambda nil (interactive) nil (dotimes (n 2) (unless (phi-search--search-forward #("t" 0 1 (face nil)) nil nil (zerop n)) (goto-char (point-min)) (phi-search--search-forward #("t" 0 1 (face nil)) nil nil t))) (phi-search--open-invisible-permanently) nil))
  symbol-name((lambda nil (interactive) nil (dotimes (n 2) (unless (phi-search--search-forward #("t" 0 1 (face nil)) nil nil (zerop n)) (goto-char (point-min)) (phi-search--search-forward #("t" 0 1 (face nil)) nil nil t))) (phi-search--open-invisible-permanently) nil))
  company-posframe-frontend(ignore hide)
  company-posframe-unless-just-one-frontend(#f(compiled-function (command) "`company-pseudo-tooltip-frontend', but not shown for single candidates." #<bytecode 0x414397f5>) hide)
  apply(company-posframe-unless-just-one-frontend #f(compiled-function (command) "`company-pseudo-tooltip-frontend', but not shown for single candidates." #<bytecode 0x414397f5>) hide)
  company-pseudo-tooltip-unless-just-one-frontend(hide)
  company-call-frontends(hide)
  company-cancel()
  company-mode(-1)
  mc/temporarily-disable-minor-mode(company-mode)
  mapc(mc/temporarily-disable-minor-mode (company-mode auto-complete-mode flyspell-mode jedi-mode))
  mc/temporarily-disable-unsupported-minor-modes()
  multiple-cursors-mode(1)
  mc/maybe-multiple-cursors-mode()
  phi-search--mc/activate-fake-cursors()
  phi-search--mc/minibuffer-exit-hook()
  read-from-minibuffer("phi-search: " nil (keymap (47 . minibuffer-complete-slash) (backtab . minibuffer-complete-backward) (67108877 . phi-search-complete-at-beginning) (33554445 . phi-search-complete-with-selection) (3 keymap (3 . phi-search-unlimit)) (13 . phi-search-complete) (23 . phi-search-yank-word) (12 . phi-search-recenter) (27 keymap (109 . phi-search-migemo-toggle) (99 . phi-search-case-toggle) (118 . phi-search-scroll-down)) (22 . phi-search-scroll-up) (7 . phi-search-abort) (remap keymap (next-line . phi-search-maybe-next-line) (previous-line . phi-search-maybe-previous-line) (forward-char . phi-search-maybe-forward-char) (mc/mark-next-like-this-dwim . phi-search-mc/mark-next) (mc/mark-all-like-this . phi-search-mc/mark-all) (mc/mark-previous-like-this . phi-search-mc/mark-previous) (mc/mark-next-like-this . phi-search-mc/mark-next) (phi-search-backward . phi-search-again-or-previous) (phi-search . phi-search-again-or-next)) (18 . phi-search-again-or-previous) (19 . phi-search-again-or-next)))
  phi-search--initialize((" *phi-search*" (:eval (let ((total (length phi-search--overlays)) (selection phi-search--selection)) (when selection (format " [ %d / %d ]" (1+ selection) total))))) (([remap next-line] quote phi-search-maybe-next-line) ([remap previous-line] quote phi-search-maybe-previous-line) ([remap forward-char] quote phi-search-maybe-forward-char) ((kbd "C-RET") quote phi-search-complete-at-beginning) ((kbd "S-RET") quote phi-search-complete-with-selection)) nil nil phi-search--complete-function nil #f(compiled-function () #<bytecode 0x42153c21>))
  phi-search--search-initialize(nil)
  phi-search()
  phi-search-from-isearch(#f(compiled-function () #<bytecode 0x42beab59>))
  phi-search-from-isearch-mc/mark-next(1)
  funcall-interactively(phi-search-from-isearch-mc/mark-next 1)
  call-interactively(phi-search-from-isearch-mc/mark-next nil nil)
  command-execute(phi-search-from-isearch-mc/mark-next)
```