### PR TITLE
Fix issue with line endings on windows

### DIFF
--- a/company-posframe.el
+++ b/company-posframe.el
@@ -482,8 +482,4 @@ just grab the first candidate and press forward."
 
 (provide 'company-posframe)
 
-;; Local Variables:
-;; coding: utf-8-unix
-;; End:
-
 ;;; company-posframe.el ends here


### PR DESCRIPTION
Emacs will auto detect the buffer encoding, so this is not needed. Also by hardcoding this to unix line endings it breaks on windows, which uses CRLF.