### PR TITLE
Don't show empty line when company-posframe-show-metadata is nil

### DIFF
--- a/company-posframe.el
+++ b/company-posframe.el
@@ -265,8 +265,7 @@ be triggered manually using `company-posframe-quickhelp-show'."
     (apply #'posframe-show buffer
            :string contents
            :position (- (point) (length company-prefix))
-           :min-height (+ height
-                          (if company-posframe-show-indicator 1 0))
+           :min-height (+ height (if meta 1 0))
            :min-width (+ company-tooltip-minimum-width (* 2 company-tooltip-margin))
            :max-width (+ company-tooltip-maximum-width (* 2 company-tooltip-margin))
            :x-pixel-offset (* -1 company-tooltip-margin (default-font-width))


### PR DESCRIPTION
When `company-posframe-show-metadata` is nil, the current behavior is to show an empty line at the bottom of the popup.

That's pretty unappealing.