### PR TITLE
Fix flickering modeline border in macos and pgtk

### DIFF
--- a/company-posframe.el
+++ b/company-posframe.el
@@ -305,7 +305,6 @@ be triggered manually using `company-posframe-quickhelp-show'."
            :min-height (+ (+ height (if meta 1 0)) (if company-posframe-show-indicator 1 0))
            :min-width (+ company-tooltip-minimum-width (* 2 company-tooltip-margin))
            :max-width (+ company-tooltip-maximum-width (* 2 company-tooltip-margin))
-           :respect-mode-line company-posframe-show-indicator
            :font company-posframe-font
            :background-color (face-attribute 'company-tooltip :background)
            :lines-truncate t

--- a/company-posframe.el
+++ b/company-posframe.el
@@ -291,18 +291,18 @@ be triggered manually using `company-posframe-quickhelp-show'."
                                                             (substring meta 0 width)
                                                           meta)
                                                         'face 'company-posframe-metadata))
+                             "")
+                           (if company-posframe-show-indicator
+                               (concat "\n" (substring backend-names 0
+                                                       (min width (length backend-names))))
                              "")))
          (buffer (get-buffer-create company-posframe-buffer)))
     ;; FIXME: Do not support mouse at the moment, so remove mouse-face
     (setq contents (copy-sequence contents))
     (remove-text-properties 0 (length contents) '(mouse-face nil) contents)
-    (with-current-buffer buffer
-      (when company-posframe-show-indicator
-        (setq-local mode-line-format `(,(substring backend-names 0
-                                                   (min width (length backend-names)))))))
     (apply #'posframe-show buffer
            :string contents
-           :min-height (+ height (if meta 1 0))
+           :min-height (+ (+ height (if meta 1 0)) (if company-posframe-show-indicator 1 0))
            :min-width (+ company-tooltip-minimum-width (* 2 company-tooltip-margin))
            :max-width (+ company-tooltip-maximum-width (* 2 company-tooltip-margin))
            :respect-mode-line company-posframe-show-indicator


### PR DESCRIPTION
你好！
我发现在macos或者pgtk下，posframe中modeline的边框会有短暂的不连贯的现象。如图，
<img width="551" alt="Screen Shot 2022-09-03 at 3 39 01 AM" src="https://user-images.githubusercontent.com/11971417/188307595-059cb4b1-abfc-4a6e-96ca-229e653cabb0.png">

我测试过如果不使用modeline展示company-backends，而直接把company-backends加入到contents中就可以避免这个情况。
